### PR TITLE
SafeWinchingClimber will now retract arm correctly on winch.

### DIFF
--- a/src/main/java/org/usfirst/frc/team449/robot/subsystem/complex/climber/SafeWinchingClimber.java
+++ b/src/main/java/org/usfirst/frc/team449/robot/subsystem/complex/climber/SafeWinchingClimber.java
@@ -55,7 +55,12 @@ public class SafeWinchingClimber extends SubsystemBase
     @Override
     public void setSolenoid(@NotNull final DoubleSolenoid.Value value) {
         solenoidSubsystem.setSolenoid(value);
-        armIsExtending = value == DoubleSolenoid.Value.kForward;
+        if(value == DoubleSolenoid.Value.kForward) {
+            armIsExtending = true;
+        } else if(value == DoubleSolenoid.Value.kReverse) {
+            armIsExtending = false;
+        }
+
         reallySure = false;
     }
 
@@ -70,7 +75,7 @@ public class SafeWinchingClimber extends SubsystemBase
             if (!reallySure) {
                 reallySure = true;
             } else {
-                setSolenoid(DoubleSolenoid.Value.kOff);
+                setSolenoid(DoubleSolenoid.Value.kReverse);
                 motorSubsystem.turnMotorOn();
                 enableArm = false;
             }


### PR DESCRIPTION
It was discovered that DoubleSolenoid.Value.kOff does not actually
disable pressure in the arm. It only cuts off current flowing to the
arm's solenoid. This will not unpressurize it but leave it in the
current state. That would cause problems during winching since it would
compete directly with the motor. Now, the arm will retract during
winching, so it will assist the motor in lifting the robot.